### PR TITLE
ユーザ+管理機能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'coffee-rails', '~> 4.2'
 gem 'turbolinks', '~> 5'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'kaminari', '~> 0.17.0'
+gem 'bcrypt', '3.1.11'
+gem 'faker'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -20,6 +22,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
+    bcrypt (3.1.11)
     better_errors (2.7.0)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -77,6 +78,10 @@ GEM
     crass (1.0.6)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     execjs (2.7.0)
     factory_bot (5.2.0)
@@ -84,6 +89,8 @@ GEM
     factory_bot_rails (5.2.0)
       factory_bot (~> 5.2.0)
       railties (>= 4.2.0)
+    faker (2.11.0)
+      i18n (>= 1.6, < 2)
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -225,13 +232,16 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (= 3.1.11)
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)
   coffee-rails (~> 4.2)
+  dotenv-rails
   factory_bot_rails
+  faker
   kaminari (~> 0.17.0)
   listen (>= 3.0.5, < 3.2)
   pg

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -16,10 +16,11 @@
  */
 body{
   text-align: center;
+  margin-bottom: 40px;
 }
 header{
   margin: 0px;
   width: 100%;
-  padding-top: calc(500 / 1200 * 100%);
-  background: url("https://cdn.pixabay.com/photo/2020/04/25/13/26/diy-5090797_960_720.jpg") center center / cover no-repeat;
+  padding-top: calc(400 / 1200 * 100%);
+  background: url("https://images.unsplash.com/photo-1453928582365-b6ad33cbcf64?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1352&q=80") center center / cover no-repeat;
 }

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -1,6 +1,5 @@
 .container{
     margin-top: 20px;
-    margin-bottom: 20px;
 }
 .table th, td{
   padding-right: 10px;

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,7 +3,8 @@ class Admin::UsersController < ApplicationController
   before_action :set_admin, only: [:show, :edit, :update, :destroy]
 
   def index
-    @users = User.all.order("created_at ASC")
+    @users = User.includes(:tasks)
+    @users = User.all.order("created_at DESC")
     @users = @users.page(params[:page]).per(10)
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,8 +1,46 @@
 class Admin::UsersController < ApplicationController
-  before_action :admin_user
+  before_action :admin_user, only: [:new, :index, :show, :edit, :update, :destroy]
+  before_action :set_admin, only: [:show, :edit, :update, :destroy]
 
   def index
-    @users = User.all.order("created_at DESC")
+    @users = User.all.order("created_at ASC")
+    @users = @users.page(params[:page]).per(10)
+  end
+
+  def show
+    @tasks = @user.tasks
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to admin_users_path, notice: t('notice.user_create')
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_user_path(@user), notice: t('notice.user_update')
+    else
+      render :new
+    end
+  end
+
+  def destroy
+    if @user.destroy
+      redirect_to admin_users_path, notice: t('notice.user_deleted')
+    else
+      redirect_to admin_users_path, notice: t('notice.user_not_deleted')
+    end
   end
 
   private
@@ -12,5 +50,13 @@ class Admin::UsersController < ApplicationController
       flash[:notice] = t('notice.not_administrator')
       redirect_to(root_path)
     end
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
+  end
+
+  def set_admin
+    @user = User.find(params[:id])
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,16 @@
+class Admin::UsersController < ApplicationController
+  before_action :admin_user
+
+  def index
+    @users = User.all.order("created_at DESC")
+  end
+
+  private
+  def admin_user
+    # admin以外のユーザはrootにリダイレクトさせる
+    if not current_user.admin
+      flash[:notice] = t('notice.not_administrator')
+      redirect_to(root_path)
+    end
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -29,7 +29,7 @@ class Admin::UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to admin_user_path(@user), notice: t('notice.user_update')
+      redirect_to admin_users_path, notice: t('notice.user_update')
     else
       render :new
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,18 @@
 class ApplicationController < ActionController::Base
+  before_action :set_current_user
   #セキュリティトークンが自動的にすべてのフォームに含まれる
   protect_from_forgery with: :exception
   include SessionsHelper
+  # ログイン中のユーザの取得の共通化
+  def set_current_user
+    @current_user = User.find_by(id: session[:user_id])
+  end
+
+  def authenticate_user
+    # 現在ログイン中のユーザが存在しない場合、ログインページにリダイレクトさせる。
+    if @current_user == nil
+      flash[:notice] = t('notice.login_needed')
+      redirect_to new_session_path
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::Base
+  #セキュリティトークンが自動的にすべてのフォームに含まれる
+  protect_from_forgery with: :exception
+  include SessionsHelper
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,4 +15,11 @@ class ApplicationController < ActionController::Base
       redirect_to new_session_path
     end
   end
+  # ログインユーザを禁止する
+  def forbid_login_user
+    if @current_user
+      flash[:notice] = t('notice.already_logged_in')
+      redirect_to tasks_path
+    end
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,23 @@
+class SessionsController < ApplicationController
+
+  def new
+  end
+  def create
+    #find_byメソッドでデータベースから該当するレコードを検索。
+    user = User.find_by(email: params[:session][:email].downcase)
+    #has_secure_passwordが提供するauthenticateメソッドを使用し、パスワード一致を確認。
+    if user && user.authenticate(params[:session][:password])
+      session[:user_id] = user.id
+      redirect_to user_path(user.id)
+    else
+      flash.now[:danger] = t('view.login_failed')
+      render :new
+    end
+  end
+
+  def destroy
+    session.delete(:user_id)
+    flash[:notice] = t('view.logged_out')
+    redirect_to new_session_path
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -22,8 +22,6 @@ class TasksController < ApplicationController
         @tasks = Task.status(params[:status]).page(params[:page]).per(10)
       end
     end
-
-
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   def index
     #params[:sort_expired]に値があれば、終了期限でソートした値を表示させる
     if params[:sort_expired]
-      @tasks = Task.all.order(end_on: :desc).page(params[:page]).per(10)
+      @tasks = Task.current_user.tasks.order(end_on: :desc).page(params[:page]).per(10)
     elsif params[:sort_priority]
       @tasks = Task.all.order(priority: :asc).page(params[:page]).per(10)
     elsif
@@ -28,7 +28,8 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = Task.new(task_params)
+    #login中のユーザのtaskをnew(build)する。
+    @task = current_user.tasks.build(task_params)
     if @task.save
       redirect_to tasks_path, notice: t('notice.create')
     else

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -32,7 +32,7 @@ class TasksController < ApplicationController
     #login中のユーザのtaskをnew(build)する。
     @task = current_user.tasks.build(task_params)
     if @task.save
-      redirect_to tasks_path, notice: t('notice.create')
+      redirect_to tasks_path, notice: t('notice.user_create')
     else
       render :new
     end
@@ -53,8 +53,11 @@ class TasksController < ApplicationController
   end
 
   def destroy
-    @task.destroy
-    redirect_to tasks_path, notice: t('notice.destroy')
+    if @task.destroy
+      redirect_to tasks_path, notice: t('notice.deleted')
+    else
+      redirect_to admin_users_path, notice: t('notice.notdeleted')
+    end
   end
 
   private
@@ -65,4 +68,4 @@ class TasksController < ApplicationController
   def set_task
     @task = Task.find(params[:id])
   end
-  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,7 +5,7 @@ class TasksController < ApplicationController
   def index
     #params[:sort_expired]に値があれば、終了期限でソートした値を表示させる
     if params[:sort_expired]
-      @tasks = Task.current_user.tasks.order(end_on: :desc).page(params[:page]).per(10)
+      @tasks = Task.all.order(end_on: :desc).page(params[:page]).per(10)
     elsif params[:sort_priority]
       @tasks = Task.all.order(priority: :asc).page(params[:page]).per(10)
     elsif

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,4 @@
-class TasksController < ApplicationController
+class Users::TasksController < ApplicationController
   before_action :authenticate_user
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,5 @@
 class TasksController < ApplicationController
+  before_action :authenticate_user
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
@@ -21,6 +22,8 @@ class TasksController < ApplicationController
         @tasks = Task.status(params[:status]).page(params[:page]).per(10)
       end
     end
+
+
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,12 +5,12 @@ class TasksController < ApplicationController
   def index
     #params[:sort_expired]に値があれば、終了期限でソートした値を表示させる
     if params[:sort_expired]
-      @tasks = Task.all.order(end_on: :desc).page(params[:page]).per(10)
+      @tasks = current_user.tasks.order(end_on: :desc).page(params[:page]).per(10)
     elsif params[:sort_priority]
-      @tasks = Task.all.order(priority: :asc).page(params[:page]).per(10)
+      @tasks = current_user.tasks.order(priority: :asc).page(params[:page]).per(10)
     elsif
       #値がなければ、Task.allで取り出せるそのままの値を出力
-      @tasks = Task.all.order(created_at: :desc).page(params[:page]).per(10)
+      @tasks = current_user.tasks.order(created_at: :desc).page(params[:page]).per(10)
     end
 
     if params[:search].present?

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,4 @@
-class Users::TasksController < ApplicationController
+class TasksController < ApplicationController
   before_action :authenticate_user
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
@@ -32,7 +32,7 @@ class Users::TasksController < ApplicationController
     #login中のユーザのtaskをnew(build)する。
     @task = current_user.tasks.build(task_params)
     if @task.save
-      redirect_to tasks_path, notice: t('notice.user_create')
+      redirect_to tasks_path, notice: t('notice.task_create')
     else
       render :new
     end
@@ -46,7 +46,7 @@ class Users::TasksController < ApplicationController
 
   def update
     if @task.update(task_params)
-      redirect_to tasks_path, notice: t('notice.update')
+      redirect_to tasks_path, notice: t('notice.task_update')
     else
       render :edit
     end
@@ -54,7 +54,7 @@ class Users::TasksController < ApplicationController
 
   def destroy
     if @task.destroy
-      redirect_to tasks_path, notice: t('notice.deleted')
+      redirect_to tasks_path, notice: t('notice.task_deleted')
     else
       redirect_to admin_users_path, notice: t('notice.notdeleted')
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,25 @@
+class UsersController < ApplicationController
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to user_path(@user.id)
+    else
+      render :new
+    end
+  end
+
+  def show
+    @user = User.find(params[:id])
+  end
+
+  private
+  def user_params
+    params.require(:user).permit(:name, :email, :password,
+                                 :password_confirmation)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,7 @@
 class UsersController < ApplicationController
   before_action :authenticate_user, { only: [:index, :show, :edit, :update] }
+  before_action :forbid_login_user, {only: :new}
+
   def new
     @user = User.new
   end
@@ -15,6 +17,14 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+  end
+  #認証されたユーザかを確かめる
+  def authenticate_user
+    # params[:id]で取得できるのは文字列、@current_user.idは数値。to_iメソッドを用いて文字列を数値に変換。
+    if @current_user.id != params[:id].to_i
+      flash[:notice] = t('notice.not_authorized')
+      redirect_to tasks_path
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,6 +29,12 @@ class UsersController < ApplicationController
     end
   end
 
+  def update
+  end
+
+  def destroy
+  end
+
   private
   def user_params
     params.require(:user).permit(:name, :email, :password,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,8 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      #新規登録時にログイン状態にする
+      session[:user_id] = @user.id
       redirect_to user_path(@user.id)
     else
       render :new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-
+  before_action :authenticate_user, { only: [:index, :show, :edit, :update] }
   def new
     @user = User.new
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,11 @@
+module SessionsHelper
+  def current_user
+    # @current_user || @current_user = User.find_by(id: session[:user_id])と同じ。@current_userが偽の場合は、右辺を代入する。
+    @current_user ||= User.find_by(id: session[:user_id])
+  end
+
+  def logged_in?
+    #presentメソッドを使用し、レシーバーの値が存在すればtrue、しなければfalseを返す。
+    current_user.present?
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,5 @@
 class Task < ApplicationRecord
+  belongs_to :user
   validates :task_name, presence: true
   validates :content, presence: true
   scope :task_name_like, -> task_name { where('task_name LIKE ?', "%#{task_name}%") }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
   validates :name, presence: true, length: { maximum: 30 }
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,9 @@
+class User < ApplicationRecord
+  has_many :tasks
+  validates :name, presence: true, length: { maximum: 30 }
+  validates :email, presence: true, length: { maximum: 255 },
+                    format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  before_validation { email.downcase! }
+  has_secure_password
+  validates :password, presence: true, length: { minimum: 6 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,16 @@
 class User < ApplicationRecord
-  has_many :tasks, dependent: :destroy
   validates :name, presence: true, length: { maximum: 30 }
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
   before_validation { email.downcase! }
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }
+  before_destroy :do_not_destroy_last_admin
+  has_many :tasks, dependent: :destroy
+
+  private
+  def do_not_destroy_last_admin
+    # コールバックで処理を停止したい時は、throw :abortする。selfをつけ、クラスメソッドを定義する。
+    throw(:abort) if User.where(admin: true).count <= 1 && self.admin?
+  end
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,21 @@
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@user.errors.count, "error") %>prohibited tihs<%= @user.name %>from being saved:</h2>
+    <ul>
+      <% @user.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+<%= form_with(model: [:admin, @user], local: true) do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+  <%= f.label :password_confirmation %>
+  <%= f.password_field :password_confirmation %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,2 @@
+<h2><%= t('view.user_update')%></h2>
+<%= render 'form' %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,7 +1,9 @@
+<%= link_to t('view.user_create'), new_admin_user_path %>
 <h1><%= t('view.admin_screen')%>: <%= t('view.user_list')%></h1>
 
 <% @users.each do |user| %>
   <%= user.id %>: <%= user.name %>
+  <%= link_to t('view.user_update'), edit_admin_user_path(user.id) %>
   <%= link_to t('view.user_delete'), [:admin, user], method: :delete,
                                            data: { confirm: t('view.confirm')} %>
 <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t('view.admin_screen')%>: <%= t('view.user_list')%></h1>
+
+<% @users.each do |user| %>
+  <%= user.id %>: <%= user.name %>
+<% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,4 +2,7 @@
 
 <% @users.each do |user| %>
   <%= user.id %>: <%= user.name %>
+  <%= link_to t('view.user_delete'), [:admin, user], method: :delete,
+                                           data: { confirm: t('view.confirm')} %>
 <% end %>
+<%= paginate (@users) %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -3,6 +3,8 @@
 
 <% @users.each do |user| %>
   <%= user.id %>: <%= user.name %>
+  <%= user.tasks.count %>
+  <%= link_to t('view.check_contents'), admin_user_path(user.id) %>
   <%= link_to t('view.user_update'), edit_admin_user_path(user.id) %>
   <%= link_to t('view.user_delete'), [:admin, user], method: :delete,
                                            data: { confirm: t('view.confirm')} %>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,22 +1,2 @@
 <h1><%= t('view.user_create')%></h1>
-<% if @user.errors.any? %>
-  <div id="error_explanation">
-    <h2><%= pluralize(@user.errors.count, "error") %>prohibited tihs<%= @user.name %>from being saved:</h2>
-    <ul>
-      <% @user.errors.full_messages.each do |message| %>
-      <li><%= message %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
-<%= form_with(model: @user, local: true) do |f| %>
-  <%= f.label :name %>
-  <%= f.text_field :name %>
-  <%= f.label :email %>
-  <%= f.email_field :email %>
-  <%= f.label :password %>
-  <%= f.password_field :password %>
-  <%= f.label :password_confirmation %>
-  <%= f.password_field :password_confirmation %>
-  <%= f.submit %>
-<% end %>
+<%= render 'form' %>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,22 @@
+<h1><%= t('view.user_create')%></h1>
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@user.errors.count, "error") %>prohibited tihs<%= @user.name %>from being saved:</h2>
+    <ul>
+      <% @user.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+<%= form_with(model: @user, local: true) do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+  <%= f.label :password_confirmation %>
+  <%= f.password_field :password_confirmation %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,29 @@
+<p>
+  ID:<%= @user.id %>
+</p>
+
+<p>
+  <%= t('view.name') %>:<%= @user.name %>
+</p>
+
+<p><%= t('view.email') %>:<%= @user.email %>
+</p>
+
+<p>
+  <%= t('view.task_list') %>
+  <br>
+  <table align="center">
+    <tr>
+      <th><%= t('view.task_name') %></th>
+      <th><%= t('view.content') %></th>
+    </tr>
+
+    <% @tasks.each do |task| %>
+      <tr class = "task_row">
+        <td><%= task.task_name %></td>
+        <td><%= task.content %></td>
+      </tr>
+    <% end %>
+  </table>
+</p>
+<%= link_to t('view.back_admin_screen'), admin_users_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,16 @@
   <body>
     <header>
     </header>
+    <% flash.each do |key, value| %>
+      <%= content_tag(:div, value, class: "#{key}") %>
+    <% end %>
+    <% if logged_in? %>
+      <%= link_to t('view.profile'), user_path(current_user.id) %>
+      <%= link_to t('view.logout'), session_path(current_user.id), method: :delete %>
+    <% else %>
+      <%= link_to t('view.signup'), new_user_path %>
+      <%= link_to t('view.login'), new_session_path %>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,8 @@
+<h1><%= t('view.login') %></h1>
+<%= form_with(scope: :session, url: sessions_path, local: true) do |f| %>
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+  <%= f.submit t('view.login')%>
+<% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -27,7 +27,7 @@
   </div>
   <div class="priority">
     <%= form.label :priority %>
-    <%= form.select :priority, [ t('view.high'), t('view.medium'), t('view.row')], { include_blank: true } %>
+    <%= form.select :priority, [ t('view.high'), t('view.middle'), t('view.row')], { include_blank: true } %>
   </div>
   <%= form.submit %>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-<%= link_to t('view.create_task'), new_task_path %><br>
+<%= link_to t('view.create_task'), new_task_path %>
 <%= link_to t('view.sort_end_date'), tasks_path(sort_expired: "true") %>
 <%= link_to t('view.sort_high_priority'), tasks_path(sort_priority: "true")%>
 <br>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -20,27 +20,28 @@
 
 <h1><%= t('view.task_list')%></h1>
 <p><%= notice %></p>
-<div class="">
-<table align="center">
-  <tr>
-    <th><%= t('view.enddeadline') %></th>
-    <th><%= t('view.task_name') %></th>
-    <th><%= t('view.content') %></th>
-    <th><%= t('view.status') %></th>
-    <th><%= t('view.priority') %></th>
-  </tr>
-<% @tasks.each do |task| %>
-  <tr>
-    <td class="date_row"><%= task.end_on %></td>
-    <td class="task_row"><%= task.task_name %></td>
-    <td><%= task.content %></td>
-    <td><%= task.status %></td>
-    <td><%= task.priority %></td>
-    <td><%= link_to t('view.check_contents'), task_path(task.id) %></td>
-    <td><%= link_to t('view.edit_task'), edit_task_path(task.id) %></td>
-    <td><%= link_to t('view.delete_task'), task_path(task.id), method: :delete, data: {confirm: t('view.confirm')} %></td>
-  </tr>
-<% end %>
-<%= paginate @tasks %>
-</table>
+<div class="table">
+  <table align="center">
+    <tr>
+      <th><%= t('view.enddeadline') %></th>
+      <th><%= t('view.task_name') %></th>
+      <th><%= t('view.content') %></th>
+      <th><%= t('view.status') %></th>
+      <th><%= t('view.priority') %></th>
+    </tr>
+  <% @tasks.each do |task| %>
+    <tr>
+      <td class="date_row"><%= task.end_on %></td>
+      <td class="task_row"><%= task.task_name %></td>
+      <td><%= task.content %></td>
+      <td><%= task.status %></td>
+      <td><%= task.priority %></td>
+      <td><%= link_to t('view.check_contents'), task_path(task.id) %></td>
+      <td><%= link_to t('view.edit_task'), edit_task_path(task.id) %></td>
+      <td><%= link_to t('view.delete_task'), task_path(task.id), method: :delete, data: {confirm: t('view.confirm')} %></td>
+    </tr>
+  <% end %>
+  <%= paginate @tasks %>
+  </table>
+</div>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -19,7 +19,6 @@
 </div>
 
 <h1><%= t('view.task_list')%></h1>
-<p><%= notice %></p>
 <div class="table">
   <table align="center">
     <tr>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,22 @@
+<h1><%= t('view.signup') %></h1>
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@user.errors.count, "error") %>prohibited this <%= @user.name %>from being saved:</h2>
+    <ul>
+      <% @user.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+<%= form_with(model: @user, local: true) do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+  <%= f.label :password_confirmation %>
+  <%= f.password_field :password_confirmation %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,5 @@
 <h1><%= @user.name %><%= t('view.ofpage') %></h1>
 <p><%= t('view.email') %>:<%= @user.email %></p>
+
 <%= link_to t('view.create_task'), new_task_path %><br>
 <%= link_to t('view.task_list'), tasks_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,4 @@
+<h1><%= @user.name %><%= t('view.ofpage') %></h1>
+<p><%= t('view.email') %>:<%= @user.email %></p>
+<%= link_to t('view.create_task'), new_task_path %><br>
+<%= link_to t('view.task_list'), tasks_path %>

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     models:
       task: タスク
+      user: ユーザー
       priority: 優先順位
     attributes:
       task:
@@ -13,3 +14,11 @@ ja:
         high: 高
         medium: 中
         row: 低
+      user:
+        name: 名前
+        email: メールアドレス
+        current_password: 現在のパスワード
+        password: パスワード
+        password_confirmation: 確認用パスワード
+        remember_me: ログインを記憶
+    

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -36,6 +36,7 @@ ja:
     create: タスクを作成しました！
     update: タスクを編集しました！
     destroy: タスクを削除しました！
+    login_needed: ログインが必要です！
   helpers:
       submit:
         create: 登録する

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -20,7 +20,7 @@ ja:
     priority: 優先順位
     peding: 未着手
     high: 高
-    medium: 中
+    middle: 中
     row: 低
     signup: サインアップ
     login: ログイン

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -36,6 +36,9 @@ ja:
     user_delete: ユーザを削除する
     user_create: ユーザを作成する
     user_update: ユーザを更新する
+    name: 名前
+    email: メールアドレス
+    back_admin_screen: 管理画面に戻る
 
   notice:
     task_create: タスクを作成しました！

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -38,9 +38,10 @@ ja:
     user_update: ユーザを更新する
 
   notice:
-    create: タスクを作成しました！
-    update: タスクを編集しました！
-    destroy: タスクを削除しました！
+    task_create: タスクを作成しました！
+    task_update: タスクを編集しました！
+    task_deleted: タスクを削除しました！
+    not_deleted: 削除できません！
     login_needed: ログインが必要です！
     already_logged_in: すでにログインしています！
     not_authorized: 権限がありません！

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -33,6 +33,8 @@ ja:
     profile: プロフィール
     admin_screen: 管理画面
     user_list: ユーザ一覧
+    user_delete: ユーザを削除する
+    user_create: ユーザを作成する
 
   notice:
     create: タスクを作成しました！
@@ -42,6 +44,11 @@ ja:
     already_logged_in: すでにログインしています！
     not_authorized: 権限がありません！
     not_administrator: あなたは管理者ではありません！
+    user_deleted: ユーザを削除しました！
+    user_create: ユーザを登録しました！
+    user_update: ユーザを更新しました！
+    user_deleted: ユーザを削除しました！
+    user_not_deleted: ユーザを削除できません！
   helpers:
       submit:
         create: 登録する

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -37,6 +37,8 @@ ja:
     update: タスクを編集しました！
     destroy: タスクを削除しました！
     login_needed: ログインが必要です！
+    already_logged_in: すでにログインしています！
+    not_authorized: 権限がありません！
   helpers:
       submit:
         create: 登録する

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -22,12 +22,22 @@ ja:
     high: 高
     medium: 中
     row: 低
+    signup: サインアップ
+    login: ログイン
+    logout: ログアウト
+    ofpage: のページ
+    email: メールアドレス
+    password: パスワード
+    login_failed: ログインに失敗しました！
+    logged_out: ログアウトしました！
+    profile: プロフィール
+
   notice:
     create: タスクを作成しました！
     update: タスクを編集しました！
     destroy: タスクを削除しました！
   helpers:
-    submit:
-      create: 登録する
-      update: 更新する
-      search: 検索する
+      submit:
+        create: 登録する
+        update: 更新する
+        search: 検索する

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -35,6 +35,7 @@ ja:
     user_list: ユーザ一覧
     user_delete: ユーザを削除する
     user_create: ユーザを作成する
+    user_update: ユーザを更新する
 
   notice:
     create: タスクを作成しました！

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -31,6 +31,8 @@ ja:
     login_failed: ログインに失敗しました！
     logged_out: ログアウトしました！
     profile: プロフィール
+    admin_screen: 管理画面
+    user_list: ユーザ一覧
 
   notice:
     create: タスクを作成しました！
@@ -39,6 +41,7 @@ ja:
     login_needed: ログインが必要です！
     already_logged_in: すでにログインしています！
     not_authorized: 権限がありません！
+    not_administrator: あなたは管理者ではありません！
   helpers:
       submit:
         create: 登録する

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get 'sessions/new'
   root to: 'tasks#index'
   resources :tasks
+  resources :sessions, only: [:new, :create, :destroy]
+  resources :users, only: [:new, :create, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'sessions/new'
   root to: 'tasks#index'
   resources :tasks
   resources :sessions, only: [:new, :create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,7 @@ Rails.application.routes.draw do
   resources :tasks
   resources :sessions, only: [:new, :create, :destroy]
   resources :users, only: [:new, :create, :show]
+  namespace :admin do
+    resources :users
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root to: 'tasks#index'
   resources :tasks
   resources :sessions, only: [:new, :create, :destroy]
-  resources :users, only: [:new, :create, :show]
+  resources :users
   namespace :admin do
     resources :users
   end

--- a/db/migrate/20200514105644_create_users.rb
+++ b/db/migrate/20200514105644_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.string :password_digest
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200514111040_add_index_to_users_email.rb
+++ b/db/migrate/20200514111040_add_index_to_users_email.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsersEmail < ActiveRecord::Migration[5.2]
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20200515025503_add_user_ref_to_tasks.rb
+++ b/db/migrate/20200515025503_add_user_ref_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddUserRefToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :tasks, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20200515092313_add_admin_to_user.rb
+++ b/db/migrate/20200515092313_add_admin_to_user.rb
@@ -1,0 +1,5 @@
+class AddAdminToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,18 @@
-ActiveRecord::Schema.define(version: 2020_05_14_024426) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
 
+ActiveRecord::Schema.define(version: 2020_05_15_025503) do
+
+  # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
@@ -10,7 +23,19 @@ ActiveRecord::Schema.define(version: 2020_05_14_024426) do
     t.date "end_on"
     t.string "status"
     t.integer "priority"
+    t.bigint "user_id"
     t.index ["task_name", "status"], name: "index_tasks_on_task_name_and_status"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "tasks", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_15_025503) do
+ActiveRecord::Schema.define(version: 2020_05_15_092313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2020_05_15_025503) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,8 +16,8 @@ ActiveRecord::Schema.define(version: 2020_05_15_092313) do
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
-    t.string "task_name"
-    t.text "content"
+    t.string "task_name", null: false
+    t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "end_on"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,10 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+1.times do |n|
+  email = Faker::Internet.email
+  name = "name"
+  password = "password"
+  User.create!(name: name,
+               email: email,
+               password: password,
+               password_confirmation: password,
+               )
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,9 @@
+User.create!(name: "admin",
+             email: "admin@gmail.com",
+             password: "foobar",
+             password_confirmation: "foobar",
+             admin: true)
+
 1.times do |n|
   email = Faker::Internet.email
   name = "name"

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     end_on {'2020-05-11'}
     status {(I18n.t('view.wip'))}
     priority {'高'}
+    user_id { 10 }
   end
 
   factory :new_task, class: Task do
@@ -13,5 +14,6 @@ FactoryBot.define do
     end_on {'2020-05-12'}
     status {(I18n.t('view.wip'))}
     priority {'高'}
+    user_id { 20 }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user do
+    
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,16 @@
 FactoryBot.define do
   factory :user do
-    
+    id { 10 }
+    name { 'sample' }
+    email { 'sample@example.com' }
+    password { '000000' }
+    admin { false }
+  end
+  factory :admin_user, class: User do
+    id { 20 }
+    name { 'admin' }
+    email { 'admin@example.com' }
+    password { '000000' }
+    admin { true }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -2,14 +2,17 @@ require 'rails_helper'
 RSpec.describe 'タスク管理機能', type: :system do
   before do
     @user = FactoryBot.create(:user)
-    @task = FactoryBot.create(:task)
-    @new_task = FactoryBot.create(:new_task)
+    @task = FactoryBot.create(:task, user: @user)
+    @new_task = FactoryBot.create(:new_task, user: @user)
+    visit new_session_path
+    fill_in "session_email", with: "sample@example.com"
+    fill_in "session_password", with: "000000"
+    click_button (I18n.t('view.login'))
   end
 
   describe 'タスク一覧画面' do
     context 'タスクを作成した場合' do
       it '作成済みのタスクが表示される' do
-        visit new_user_path
         visit tasks_path
         expect(page).to have_content 'task'
       end
@@ -17,7 +20,6 @@ RSpec.describe 'タスク管理機能', type: :system do
 
     context '複数のタスクを作成した場合' do
       it 'タスクが作成日時の降順に並んでいる' do
-        visit new_user_path
         visit tasks_path
         task_list = all('.task_row')
         expect(task_list[0]).to have_content 'new_task'
@@ -26,13 +28,7 @@ RSpec.describe 'タスク管理機能', type: :system do
     end
 
     context 'scopeメソッドで検索をした場合' do
-      before do
-        @user = FactoryBot.create(:user)
-        @task = FactoryBot.create(:task)
-        @new_task = FactoryBot.create(:new_task)
-      end
       it "scopeメソッドでタスク名検索ができる" do
-        visit new_user_path
         #タスク一覧ページに飛ぶ
         visit tasks_path
         #タスクの検索欄に検索ワードを入力する(例: task)
@@ -42,14 +38,12 @@ RSpec.describe 'タスク管理機能', type: :system do
         expect(page).to have_content 'task'
       end
       it "scopeメソッドでステータス検索ができる" do
-        visit new_user_path
         visit tasks_path
         select (I18n.t('view.wip')), from: 'status'
         click_button (I18n.t('helpers.submit.search'))
         expect(page).to have_selector 'td',text: (I18n.t('view.wip'))
       end
       it "scopeメソッドでタスク名とステータスの両方が検索できる" do
-        visit new_user_path
         visit tasks_path
         select (I18n.t('view.wip')), from: 'status'
         fill_in 'task_name', with: 'task'
@@ -63,7 +57,6 @@ RSpec.describe 'タスク管理機能', type: :system do
   describe '終了期限での並び替え' do
     context '終了期日を入力して、createボタンを押した場合' do
       it 'データが保存される' do
-        visit new_user_path
         visit new_task_path
         select '2020', from: 'task_end_on_1i'
         select '5', from: 'task_end_on_2i'
@@ -77,7 +70,6 @@ RSpec.describe 'タスク管理機能', type: :system do
 
     context '終了期限でソートするリンクをクリックした場合' do
       it 'タスクが終了期限の降順に並んでいる' do
-        visit new_user_path
         visit tasks_path
         click_link (I18n.t('view.sort_end_date'))
         task_list = all('.date_row')
@@ -90,7 +82,6 @@ RSpec.describe 'タスク管理機能', type: :system do
   describe 'タスク登録画面' do
     context '必要項目を入力して、createボタンを押した場合' do
       it 'データが保存される' do
-        visit new_user_path
         visit new_task_path
         click_button (I18n.t('helpers.submit.create'))
         expect(page).to have_content 'task'

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 RSpec.describe 'タスク管理機能', type: :system do
   before do
-    @user = FactoryBot.create(:user)
-    @task = FactoryBot.create(:task, user: @user)
-    @new_task = FactoryBot.create(:new_task, user: @user)
+    @user = create(:user)
+    @task = create(:task, user: @user)
+    @new_task = create(:new_task, user: @user)
     visit new_session_path
     fill_in "session_email", with: "sample@example.com"
     fill_in "session_password", with: "000000"

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 RSpec.describe 'タスク管理機能', type: :system do
   before do
+    @user = FactoryBot.create(:user)
     @task = FactoryBot.create(:task)
     @new_task = FactoryBot.create(:new_task)
   end
@@ -8,6 +9,7 @@ RSpec.describe 'タスク管理機能', type: :system do
   describe 'タスク一覧画面' do
     context 'タスクを作成した場合' do
       it '作成済みのタスクが表示される' do
+        visit new_user_path
         visit tasks_path
         expect(page).to have_content 'task'
       end
@@ -15,6 +17,7 @@ RSpec.describe 'タスク管理機能', type: :system do
 
     context '複数のタスクを作成した場合' do
       it 'タスクが作成日時の降順に並んでいる' do
+        visit new_user_path
         visit tasks_path
         task_list = all('.task_row')
         expect(task_list[0]).to have_content 'new_task'
@@ -24,10 +27,12 @@ RSpec.describe 'タスク管理機能', type: :system do
 
     context 'scopeメソッドで検索をした場合' do
       before do
+        @user = FactoryBot.create(:user)
         @task = FactoryBot.create(:task)
         @new_task = FactoryBot.create(:new_task)
       end
       it "scopeメソッドでタスク名検索ができる" do
+        visit new_user_path
         #タスク一覧ページに飛ぶ
         visit tasks_path
         #タスクの検索欄に検索ワードを入力する(例: task)
@@ -37,12 +42,14 @@ RSpec.describe 'タスク管理機能', type: :system do
         expect(page).to have_content 'task'
       end
       it "scopeメソッドでステータス検索ができる" do
+        visit new_user_path
         visit tasks_path
         select (I18n.t('view.wip')), from: 'status'
         click_button (I18n.t('helpers.submit.search'))
         expect(page).to have_selector 'td',text: (I18n.t('view.wip'))
       end
       it "scopeメソッドでタスク名とステータスの両方が検索できる" do
+        visit new_user_path
         visit tasks_path
         select (I18n.t('view.wip')), from: 'status'
         fill_in 'task_name', with: 'task'
@@ -56,6 +63,7 @@ RSpec.describe 'タスク管理機能', type: :system do
   describe '終了期限での並び替え' do
     context '終了期日を入力して、createボタンを押した場合' do
       it 'データが保存される' do
+        visit new_user_path
         visit new_task_path
         select '2020', from: 'task_end_on_1i'
         select '5', from: 'task_end_on_2i'
@@ -69,6 +77,7 @@ RSpec.describe 'タスク管理機能', type: :system do
 
     context '終了期限でソートするリンクをクリックした場合' do
       it 'タスクが終了期限の降順に並んでいる' do
+        visit new_user_path
         visit tasks_path
         click_link (I18n.t('view.sort_end_date'))
         task_list = all('.date_row')
@@ -81,6 +90,7 @@ RSpec.describe 'タスク管理機能', type: :system do
   describe 'タスク登録画面' do
     context '必要項目を入力して、createボタンを押した場合' do
       it 'データが保存される' do
+        visit new_user_path
         visit new_task_path
         click_button (I18n.t('helpers.submit.create'))
         expect(page).to have_content 'task'

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 RSpec.describe 'タスク管理機能', type: :system do
   before do
-    @user = create(:user)
-    @task = create(:task, user: @user)
-    @new_task = create(:new_task, user: @user)
+    @user = FactoryBot.create(:user)
+    @task = FactoryBot.create(:task, user: @user)
+    @new_task = FactoryBot.create(:new_task, user: @user)
     visit new_session_path
     fill_in "session_email", with: "sample@example.com"
     fill_in "session_password", with: "000000"

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'ユーザ登録・ログイン・ログアウト機能', type: :
 
   describe "セッション機能のテスト" do
     before do
-      @user = create(:user)
+      @user = FactoryBot.create(:user)
     end
     context "ユーザのデータがあってログインしていない場合" do
       it "ログインできること" do
@@ -65,7 +65,7 @@ RSpec.describe 'ユーザ登録・ログイン・ログアウト機能', type: :
   describe "管理画面のテスト" do
     context "アドミンユーザがない場合" do
       it "管理者は管理画面にアクセスできること" do
-        create(:admin_user)
+        FactoryBot.create(:admin_user)
         visit new_session_path
         fill_in "session_email", with: "admin@example.com"
         fill_in "session_password", with: "000000"
@@ -89,7 +89,7 @@ RSpec.describe 'ユーザ登録・ログイン・ログアウト機能', type: :
 
     context "管理者でログインしている場合" do
       before do
-        create(:admin_user)
+        FactoryBot.create(:admin_user)
         visit new_session_path
         fill_in "session_email", with: "admin@example.com"
         fill_in "session_password", with: "000000"
@@ -108,13 +108,13 @@ RSpec.describe 'ユーザ登録・ログイン・ログアウト機能', type: :
       end
 
       it "管理者はユーザ詳細画面にアクセスできること" do
-        @user = create(:user)
+        @user = FactoryBot.create(:user)
         visit admin_user_path(id: @user.id)
         expect(page).to have_content "sample"
       end
 
       it "管理者はユーザの編集画面からユーザを編集できること" do
-        @user = create(:user)
+        @user = FactoryBot.create(:user)
         visit edit_admin_user_path(id: @user.id)
         fill_in 'user_name', with: 'sample2'
         fill_in 'user_email', with: 'sample2@example.com'
@@ -125,7 +125,7 @@ RSpec.describe 'ユーザ登録・ログイン・ログアウト機能', type: :
       end
 
       it "管理者はユーザの削除をできること" do
-        @user = create(:user)
+        @user = FactoryBot.create(:user)
         visit admin_users_path
         click_on "ユーザを削除する", match: :first
         page.driver.browser.switch_to.alert.accept

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -1,0 +1,136 @@
+require 'rails_helper'
+RSpec.describe 'ユーザ登録・ログイン・ログアウト機能', type: :system do
+  describe 'ユーザ登録のテスト' do
+    context 'ユーザのデータなくログインいていない場合' do
+      it 'ユーザ新規登録のテスト' do
+        visit new_user_path
+        fill_in 'user[name]', with: 'sample'
+        fill_in 'user[email]', with: 'sample@example.com'
+        fill_in 'user[password]', with: '000000'
+        fill_in 'user[password_confirmation]', with: '000000'
+        click_on '登録する'
+        # 現在のパスがユーザid:1のパスと等しいか
+        expect(page).to have_content 'sample'
+        # expect(current_path).to eq user_path(id: 1)
+      end
+      it 'ログインしていない時はログイン画面に飛ぶテスト' do
+        visit tasks_path
+        expect(current_path).to eq new_session_path
+      end
+    end
+  end
+
+  describe "セッション機能のテスト" do
+    before do
+      @user = FactoryBot.create(:user)
+    end
+    context "ユーザのデータがあってログインしていない場合" do
+      it "ログインできること" do
+        visit new_session_path
+        fill_in 'session_email', with: @user.email
+        fill_in 'session_password', with: @user.password
+        click_button (I18n.t('view.login'))
+        expect(current_path).to eq user_path(id: @user.id)
+      end
+    end
+
+    context "ユーザのデータがあってログインしている場合" do
+      before do
+        visit new_session_path
+        fill_in "session_email", with: "sample@example.com"
+        fill_in "session_password", with: "000000"
+        click_button (I18n.t('view.login'))
+      end
+
+      it "自分の詳細画面（マイページ）に飛べること" do
+        visit user_path(id: @user.id)
+        expect(current_path).to eq user_path(id: @user.id)
+      end
+
+      it "一般ユーザが他人の詳細画面に飛ぶとタスク一覧ページに遷移すること" do
+        @admin_user = FactoryBot.create(:admin_user)
+        visit user_path(id: @admin_user.id)
+        expect(page).to have_content "権限がありません！"
+      end
+
+      it "ログアウトができること" do
+        visit user_path(id: @user.id)
+        click_link (I18n.t('view.logout'))
+        expect(current_path).to eq new_session_path
+        expect(page).to have_content "ログアウトしました！"
+      end
+    end
+  end
+
+  describe "管理画面のテスト" do
+    context "アドミンユーザがない場合" do
+      it "管理者は管理画面にアクセスできること" do
+        FactoryBot.create(:admin_user)
+        visit new_session_path
+        fill_in "session_email", with: "admin@example.com"
+        fill_in "session_password", with: "000000"
+        click_button (I18n.t('view.login'))
+        visit admin_users_path
+        expect(page).to have_content "管理画面"
+      end
+    end
+
+    context "一般ユーザでログインしている場合" do
+      it "一般ユーザは管理画面にアクセスできないこと" do
+        FactoryBot.create(:user)
+        visit new_session_path
+        fill_in "session_email", with: "sample@example.com"
+        fill_in "session_password", with: "000000"
+        click_button (I18n.t('view.login'))
+        visit admin_users_path
+        expect(page).to have_content "あなたは管理者ではありません！"
+      end
+    end
+
+    context "管理者でログインしている場合" do
+      before do
+        FactoryBot.create(:admin_user)
+        visit new_session_path
+        fill_in "session_email", with: "admin@example.com"
+        fill_in "session_password", with: "000000"
+        click_button (I18n.t('view.login'))
+        visit admin_users_path
+      end
+
+      it "管理者はユーザを新規登録できること" do
+        click_on "ユーザを作成する"
+        fill_in "user_name", with: "111"
+        fill_in "user_email", with: "111@example.com"
+        fill_in "user_password", with: "111111"
+        fill_in "user_password_confirmation", with: "111111"
+        click_on '登録する'
+        expect(page).to have_content "111"
+      end
+
+      it "管理者はユーザ詳細画面にアクセスできること" do
+        @user = FactoryBot.create(:user)
+        visit admin_user_path(id: @user.id)
+        expect(page).to have_content "sample"
+      end
+
+      it "管理者はユーザの編集画面からユーザを編集できること" do
+        @user = FactoryBot.create(:user)
+        visit edit_admin_user_path(id: @user.id)
+        fill_in 'user_name', with: 'sample2'
+        fill_in 'user_email', with: 'sample2@example.com'
+        fill_in 'user_password', with: '111111'
+        fill_in 'user_password_confirmation', with: '111111'
+        click_on '更新する'
+        expect(page).to have_content "sample2"
+      end
+
+      it "管理者はユーザの削除をできること" do
+        @user = FactoryBot.create(:user)
+        visit admin_users_path
+        click_on "ユーザを削除する", match: :first
+        page.driver.browser.switch_to.alert.accept
+        expect(page).to have_content "ユーザを削除しました！"
+      end
+    end
+  end
+end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'ユーザ登録・ログイン・ログアウト機能', type: :
 
   describe "セッション機能のテスト" do
     before do
-      @user = FactoryBot.create(:user)
+      @user = create(:user)
     end
     context "ユーザのデータがあってログインしていない場合" do
       it "ログインできること" do
@@ -65,7 +65,7 @@ RSpec.describe 'ユーザ登録・ログイン・ログアウト機能', type: :
   describe "管理画面のテスト" do
     context "アドミンユーザがない場合" do
       it "管理者は管理画面にアクセスできること" do
-        FactoryBot.create(:admin_user)
+        create(:admin_user)
         visit new_session_path
         fill_in "session_email", with: "admin@example.com"
         fill_in "session_password", with: "000000"
@@ -89,7 +89,7 @@ RSpec.describe 'ユーザ登録・ログイン・ログアウト機能', type: :
 
     context "管理者でログインしている場合" do
       before do
-        FactoryBot.create(:admin_user)
+        create(:admin_user)
         visit new_session_path
         fill_in "session_email", with: "admin@example.com"
         fill_in "session_password", with: "000000"
@@ -108,13 +108,13 @@ RSpec.describe 'ユーザ登録・ログイン・ログアウト機能', type: :
       end
 
       it "管理者はユーザ詳細画面にアクセスできること" do
-        @user = FactoryBot.create(:user)
+        @user = create(:user)
         visit admin_user_path(id: @user.id)
         expect(page).to have_content "sample"
       end
 
       it "管理者はユーザの編集画面からユーザを編集できること" do
-        @user = FactoryBot.create(:user)
+        @user = create(:user)
         visit edit_admin_user_path(id: @user.id)
         fill_in 'user_name', with: 'sample2'
         fill_in 'user_email', with: 'sample2@example.com'
@@ -125,7 +125,7 @@ RSpec.describe 'ユーザ登録・ログイン・ログアウト機能', type: :
       end
 
       it "管理者はユーザの削除をできること" do
-        @user = FactoryBot.create(:user)
+        @user = create(:user)
         visit admin_users_path
         click_on "ユーザを削除する", match: :first
         page.driver.browser.switch_to.alert.accept


### PR DESCRIPTION
#7 
ユーザ登録機能実装
ログイン、ログアウト機能実装
ログインしている時は、ユーザ登録画面に行かせないように、コントローラで制御
自分以外のユーザのマイページに行かせないように、コントローラで制御
ログインしていないのにタスクのページに飛ぼうとした場合は、ログインページに遷移させるよう設定
管理者機能を追加
管理ユーザだけがユーザ管理画面にアクセスできるよう設定
管理画面でユーザ一覧・作成・更新・削除機能実装
ユーザのSystem Spec追記